### PR TITLE
Add language options to CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rayon = "1.10.0"
 regex = { version = "1.11.1", features = ["logging", "pattern", "use_std"] }
 rust-bert = { version = "0.23.0", features = ["download-libtorch", "onnx"] }
 tch = { version = "0.17.0", features = ["download-libtorch"] }
+clap = { version = "4.5.4", features = ["derive"] }
 
 
 # Default bin


### PR DESCRIPTION
## Summary
- add `clap` dependency
- parse `--from` and `--to` CLI flags
- update log line and input/output paths to honor flags

## Testing
- `cargo build -q` *(fails: `regex` crate requires unstable features)*

------
https://chatgpt.com/codex/tasks/task_e_688602d405dc8332b11b02ebd5be7b9c